### PR TITLE
chore: Extend type for `meta` field

### DIFF
--- a/src/components/topHeader/TopHeader.vue
+++ b/src/components/topHeader/TopHeader.vue
@@ -6,7 +6,7 @@
           <Bell />
         </el-icon>
       </el-badge>
-      <el-avatar icon="UserFilled" class="ml mr"/>
+      <el-avatar icon="UserFilled" class="ml mr" />
       <el-dropdown @command="handleCommand">
         <span class="el-dropdown-link">
           欢迎您，{{ username }}
@@ -44,7 +44,6 @@ const handleCommand = (command: string) => {
     router.push('/login')
   }
 }
-
 </script>
 
 <style lang="less" scoped>
@@ -52,7 +51,7 @@ const handleCommand = (command: string) => {
   background-color: white;
   height: 60px;
   padding: 0 20px;
-  .personal{
+  .personal {
     display: flex;
     float: right;
     height: 60px;

--- a/src/router/basicRouteMap.ts
+++ b/src/router/basicRouteMap.ts
@@ -1,5 +1,13 @@
 import { type RouteRecordRaw } from 'vue-router'
 
+// 扩展 meta 字段的类型
+// 参考 https://router.vuejs.org/zh/guide/advanced/meta.html#TypeScript
+declare module 'vue-router' {
+  interface RouteMeta {
+    needAuth?: string[]
+  }
+}
+
 const routes: RouteRecordRaw[] = [
   {
     path: '/',

--- a/src/router/guard.ts
+++ b/src/router/guard.ts
@@ -17,7 +17,10 @@ router.beforeEach((to) => {
     }
     if (
       to.meta.needAuth &&
-      !userStore.roles.some((role: string) => (to.meta.needAuth as string[]).includes(role))
+      // 在 @/router/index.ts 中, 使用 RouteMeta 接口扩展 meta 字段的类型
+      // 所以这里不再需要使用类型断言了
+      // 后续如果有新增字段, 可以继续使用 RouteMeta 接口扩展 meta 字段的类型
+      !userStore.roles.some((role: string) => to.meta.needAuth?.includes(role))
     ) {
       // 已登录但无权访问
       return { path: '/' }

--- a/src/router/guard.ts
+++ b/src/router/guard.ts
@@ -17,8 +17,8 @@ router.beforeEach((to) => {
     }
     if (
       to.meta.needAuth &&
-      // 在 @/router/index.ts 中, 使用 RouteMeta 接口扩展 meta 字段的类型
-      // 所以这里不再需要使用类型断言了
+      // 在 @/router/basicRouteMap.ts 中, 使用 RouteMeta 接口扩展 meta 字段的类型
+      // 所以这里不再需要使用类型断言
       // 后续如果有新增字段, 可以继续使用 RouteMeta 接口扩展 meta 字段的类型
       !userStore.roles.some((role: string) => to.meta.needAuth?.includes(role))
     ) {


### PR DESCRIPTION
可以扩展 meta 字段的类型, 获得更好的代码提示
参考 [扩展 meta 字段的类型](https://router.vuejs.org/zh/guide/advanced/meta.html#TypeScript)

```ts
declare module 'vue-router' {
  interface RouteMeta {
    needAuth?: string[]
  }
}
```

Smile everyday~