### PR TITLE
feat: Add debugger config, beautify style, temporarily resolved the F…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+stats.html

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "*.{vue,js,cjs,mjs,jsx,ts,cts,mts,tsx,json,css,less,scss,md,mdx}": [
       "pnpm format"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/src/components/topHeader/TopHeader.vue
+++ b/src/components/topHeader/TopHeader.vue
@@ -58,4 +58,9 @@ const handleCommand = (command: string) => {
     align-items: center;
   }
 }
+
+.el-dropdown-link {
+  outline-style: none;
+  cursor: pointer;
+}
 </style>

--- a/src/hooks/useCharts.ts
+++ b/src/hooks/useCharts.ts
@@ -1,7 +1,5 @@
 import { onMounted, onUnmounted, ref, type Ref, markRaw } from 'vue'
 import echarts, { type ECOption } from '@/utils/typedEchart'
-import { LineChart } from 'echarts/charts'
-echarts.use([LineChart])
 
 export function useCharts(chartRef: Ref<HTMLElement | null>, initialOptions: ECOption) {
   const chartInstance = ref<echarts.ECharts | null>(null)

--- a/src/hooks/useCharts.ts
+++ b/src/hooks/useCharts.ts
@@ -1,10 +1,9 @@
 import { onMounted, onUnmounted, ref, type Ref, markRaw } from 'vue'
-import * as echarts from 'echarts'
+import echarts, { type ECOption } from '@/utils/typedEchart'
+import { LineChart } from 'echarts/charts'
+echarts.use([LineChart])
 
-export function useCharts(
-  chartRef: Ref<HTMLElement | null>,
-  initialOptions: echarts.EChartsOption,
-) {
+export function useCharts(chartRef: Ref<HTMLElement | null>, initialOptions: ECOption) {
   const chartInstance = ref<echarts.ECharts | null>(null)
   const chartOptions = ref(initialOptions)
   const initChart = () => {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -23,15 +23,7 @@ export const useUserStore = defineStore('user', {
   actions: {
     async login(data: LoginParams) {
       try {
-        // 解构赋值
-        // 参考 https://wangdoc.com/es6/destructuring#%E5%AF%B9%E8%B1%A1%E7%9A%84%E8%A7%A3%E6%9E%84%E8%B5%8B%E5%80%BC
-        const {
-          data: {
-            token,
-            user: { username, roles },
-            menulist,
-          },
-        } = (await loginApi(data)) as {
+        const res = (await loginApi(data)) as {
           // 断言 await 得到的对象类型
           data: {
             token: string
@@ -39,6 +31,14 @@ export const useUserStore = defineStore('user', {
             menulist: MenuItem[]
           }
         }
+
+        // 解构赋值
+        // 参考 https://wangdoc.com/es6/destructuring#%E5%AF%B9%E8%B1%A1%E7%9A%84%E8%A7%A3%E6%9E%84%E8%B5%8B%E5%80%BC
+        const {
+          token,
+          user: { username, roles },
+          menulist,
+        } = res.data
 
         this.token = token
         this.roles = roles

--- a/src/utils/typedEchart.ts
+++ b/src/utils/typedEchart.ts
@@ -1,0 +1,71 @@
+import * as echarts from 'echarts/core'
+
+import { BarChart, LineChart, PieChart, RadarChart } from 'echarts/charts'
+
+import type {
+  // 系列类型的定义后缀都为 SeriesOption
+  BarSeriesOption,
+  LineSeriesOption,
+  PieSeriesOption,
+  RadarSeriesOption,
+} from 'echarts/charts'
+
+import {
+  TitleComponent,
+  TooltipComponent,
+  GridComponent,
+  DatasetComponent,
+  TransformComponent,
+  LegendComponent,
+  GraphicComponent,
+} from 'echarts/components'
+
+import type {
+  // 组件类型的定义后缀都为 ComponentOption
+  TitleComponentOption,
+  TooltipComponentOption,
+  GridComponentOption,
+  DatasetComponentOption,
+  // TransformComponentOption,
+  LegendComponentOption,
+  GraphicComponentOption,
+} from 'echarts/components'
+
+import { LabelLayout, UniversalTransition } from 'echarts/features'
+import { CanvasRenderer } from 'echarts/renderers'
+
+import type { ComposeOption } from 'echarts/core'
+
+export type ECOption = ComposeOption<
+  | BarSeriesOption
+  | LineSeriesOption
+  | PieSeriesOption
+  | RadarSeriesOption
+  | TitleComponentOption
+  | TooltipComponentOption
+  | GridComponentOption
+  | DatasetComponentOption
+  | LegendComponentOption
+  | GraphicComponentOption
+>
+
+echarts.use([
+  TitleComponent,
+  TooltipComponent,
+  GridComponent,
+  DatasetComponent,
+  TransformComponent,
+  LegendComponent,
+  GraphicComponent,
+
+  BarChart,
+  LineChart,
+  PieChart,
+  RadarChart,
+
+  LabelLayout,
+  UniversalTransition,
+  CanvasRenderer,
+])
+
+export default echarts

--- a/src/views/dashboard/DashBoard.vue
+++ b/src/views/dashboard/DashBoard.vue
@@ -131,6 +131,10 @@ const chartRef = ref(null)
 let myChart: echarts.ECharts | null = null
 let option: echarts.EChartsOption
 
+interface IEvent {
+  axesInfo: { value: number }[]
+}
+
 onMounted(() => {
   if (chartRef.value) {
     myChart = echarts.init(chartRef.value)
@@ -193,8 +197,8 @@ onMounted(() => {
 
     myChart.setOption(option)
     // FIXME: 首先是这个类型，其次写了一个 useCharts.ts 但是没用上
-    myChart.on('updateAxisPointer', function (event: any) {
-      const xAxisInfo = event.axesInfo[0]
+    myChart.on('updateAxisPointer', function (event) {
+      const xAxisInfo = (event as IEvent).axesInfo[0]
       if (xAxisInfo) {
         const dimension = xAxisInfo.value + 1
         myChart?.setOption<echarts.EChartsOption>({

--- a/src/views/dashboard/DashBoard.vue
+++ b/src/views/dashboard/DashBoard.vue
@@ -125,11 +125,14 @@ import flash from '@/assets/flash.png'
 import flash2 from '@/assets/flash2.png'
 import flash3 from '@/assets/flash3.png'
 import { onMounted, onUnmounted, ref } from 'vue'
-import * as echarts from 'echarts'
+
+// import * as echarts from 'echarts'
+import echarts, { type ECOption } from '@/utils/typedEchart'
 
 const chartRef = ref(null)
 let myChart: echarts.ECharts | null = null
-let option: echarts.EChartsOption
+// let option: echarts.EChartsOption
+let option: ECOption
 
 interface IEvent {
   axesInfo: { value: number }[]
@@ -201,7 +204,8 @@ onMounted(() => {
       const xAxisInfo = (event as IEvent).axesInfo[0]
       if (xAxisInfo) {
         const dimension = xAxisInfo.value + 1
-        myChart?.setOption<echarts.EChartsOption>({
+        // myChart?.setOption<echarts.EChartsOption>({
+        myChart?.setOption<ECOption>({
           series: {
             id: 'pie',
             label: {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,15 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": false,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "sourceMap": true
   },
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue","src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx"]
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "src/**/*.vue",
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 import AutoImport from 'unplugin-auto-import/vite'
 import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -20,6 +21,8 @@ export default defineConfig({
     Components({
       resolvers: [ElementPlusResolver()],
     }),
+    // pnpm build
+    visualizer({ open: true }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
添加了调试文件, 点击绿色按钮即可开启调试, 可以在 vscode 中, 对期望中断的地方打上断点
也可以在代码中插入 `debugger`, 参考 [debugger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger)

<img width="263" height="199" alt="image" src="https://github.com/user-attachments/assets/da5ba996-53d7-4e5b-b28b-e39e2ac05820" />

优化了样式, 个人觉得这里不太好看, 去除了边框, 增加了 hover 时的小手

<img width="438" height="409" alt="9130d1896250ce76ca2667646ec81a67" src="https://github.com/user-attachments/assets/4e3d0eed-15f4-47a0-a516-b34028a7dbea" />

`@/utils/typedEchart.ts` 该文件实现了 echart 的按需导入

原写法

```ts
import * as echarts from 'echarts';

let option: echarts.EChartsOption
```

需要改为

```ts
// import * as echarts from 'echarts'
import echarts, { type ECOption } from '@/utils/typedEchart'

// let option: echarts.EChartsOption
let option: ECOption
```

即 `import * as echarts from 'echarts';` 需要改为 `import echarts from '@/utils/typedEchart'`

类型 `echarts.EChartsOption` 需要改为 `import { type ECOption } from '@/utils/typedEchart'` 这里的 `ECOption`

最后, 添加了打包体积的可视化插件, 运行 `pnpm build` 即可查看打包后的产物, echart 体积明显下降
